### PR TITLE
Avoid split data files in check

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@
 #' @export
 #' @importFrom utils tail
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # Run on given data
 #' df <- as.data.frame(syngrowth)
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -80,7 +80,7 @@ The rest of this documentation includes:
 
 - [Configuration options](articles/configuration.html) - changing growthcleanr operational
   settings
-- [Understanding growthclenar output](articles/output.html) - the exclusion
+- [Understanding growthcleanr output](articles/output.html) - the exclusion
   types growthcleanr identifies
 - [Adult algorithm](articles/adult-algorithm.html) - a detailed description of
   how growthcleanr assesses observations from adult subjects

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The rest of this documentation includes:
 
 -   [Configuration options](articles/configuration.html) - changing
     growthcleanr operational settings
--   [Understanding growthclenar output](articles/output.html) - the
+-   [Understanding growthcleanr output](articles/output.html) - the
     exclusion types growthcleanr identifies
 -   [Adult algorithm](articles/adult-algorithm.html) - a detailed
     description of how growthcleanr assesses observations from adult

--- a/docs/index.html
+++ b/docs/index.html
@@ -147,7 +147,7 @@
 <li>
 <a href="articles/configuration.html">Configuration options</a> - changing growthcleanr operational settings</li>
 <li>
-<a href="articles/output.html">Understanding growthclenar output</a> - the exclusion types growthcleanr identifies</li>
+<a href="articles/output.html">Understanding growthcleanr output</a> - the exclusion types growthcleanr identifies</li>
 <li>
 <a href="articles/adult-algorithm.html">Adult algorithm</a> - a detailed description of how growthcleanr assesses observations from adult subjects</li>
 <li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -11,5 +11,5 @@ articles:
   quickstart: quickstart.html
   usage: usage.html
   utilities: utilities.html
-last_built: 2021-06-13T20:42Z
+last_built: 2021-06-13T22:44Z
 

--- a/docs/reference/splitinput.html
+++ b/docs/reference/splitinput.html
@@ -206,21 +206,20 @@ result.</p>
     <p>the count number referring to the last split file written</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
-    <pre class="examples"><div class='input'><span class='co'># \donttest{</span>
+    <pre class="examples"><div class='input'><span class='kw'>if</span> <span class='op'>(</span><span class='cn'>FALSE</span><span class='op'>)</span> <span class='op'>{</span>
 <span class='co'># Run on given data</span>
 <span class='va'>df</span> <span class='op'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/as.data.frame.html'>as.data.frame</a></span><span class='op'>(</span><span class='va'>syngrowth</span><span class='op'>)</span>
 
 <span class='co'># Run with all defaults</span>
 <span class='fu'>splitinput</span><span class='op'>(</span><span class='va'>df</span><span class='op'>)</span>
-</div><div class='output co'>#&gt; [1] 7</div><div class='input'>
+
 <span class='co'># Specifying the name, directory and minimum row size</span>
 <span class='fu'>splitinput</span><span class='op'>(</span><span class='va'>df</span>, fname <span class='op'>=</span> <span class='st'>"syngrowth"</span>, fdir <span class='op'>=</span> <span class='fu'><a href='https://rdrr.io/r/base/tempfile.html'>tempdir</a></span><span class='op'>(</span><span class='op'>)</span>, min_nrow <span class='op'>=</span> <span class='fl'>5000</span><span class='op'>)</span>
-</div><div class='output co'>#&gt; [1] 15</div><div class='input'>
+
 <span class='co'># Specifying a different subject ID column</span>
 <span class='fu'><a href='https://rdrr.io/r/base/colnames.html'>colnames</a></span><span class='op'>(</span><span class='va'>df</span><span class='op'>)</span><span class='op'>[</span><span class='fu'><a href='https://rdrr.io/r/base/colnames.html'>colnames</a></span><span class='op'>(</span><span class='va'>df</span><span class='op'>)</span> <span class='op'>==</span> <span class='st'>"subjid"</span><span class='op'>]</span> <span class='op'>&lt;-</span> <span class='st'>"sub_id"</span>
 <span class='fu'>splitinput</span><span class='op'>(</span><span class='va'>df</span>, keepcol <span class='op'>=</span> <span class='st'>"sub_id"</span><span class='op'>)</span>
-</div><div class='output co'>#&gt; [1] 7</div><div class='input'>
-<span class='co'># }</span>
+<span class='op'>}</span>
 </div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/man/splitinput.Rd
+++ b/man/splitinput.Rd
@@ -34,7 +34,7 @@ in one file. Pads split filenames with zeros out to five digits for consistency,
 result.
 }
 \examples{
-\donttest{
+\dontrun{
 # Run on given data
 df <- as.data.frame(syngrowth)
 


### PR DESCRIPTION
Changed `dontest` in `splitinput()` to `dontrun`, avoids split input files note in CHECK, fixes https://github.com/carriedaymont/growthcleanr/issues/60